### PR TITLE
ondersteuning voor TMS kaartlagen (dus ook TMS als niet-basislaag)

### DIFF
--- a/public/js/dbkjs/dbkjs.js
+++ b/public/js/dbkjs/dbkjs.js
@@ -198,6 +198,7 @@ dbkjs.successAuth = function() {
                     if (!dbkjs.util.isJsonNull(wms_v.pl)){
                         metadata.pl = wms_v.pl;
                     }
+                    var layertype = wms_v.layertype || null;
                     var myLayer = new dbkjs.Layer(
                         wms_v.name,
                         wms_v.url,
@@ -205,7 +206,8 @@ dbkjs.successAuth = function() {
                         options,
                         parent,
                         index,
-                        metadata
+                        metadata,
+                        layertype
                     );
                 } else {
                     var params = wms_v.params || {};
@@ -219,6 +221,7 @@ dbkjs.successAuth = function() {
                     if (!dbkjs.util.isJsonNull(wms_v.pl)){
                         metadata.pl = wms_v.pl;
                     }
+                    var layertype = wms_v.layertype || null;
                     var myLayer = new dbkjs.Layer(
                         wms_v.name,
                         wms_v.url,
@@ -226,7 +229,8 @@ dbkjs.successAuth = function() {
                         options,
                         parent,
                         index,
-                        metadata
+                        metadata,
+                        layertype
                     );
                 }
 

--- a/public/js/dbkjs/prototype/Layer.js
+++ b/public/js/dbkjs/prototype/Layer.js
@@ -53,6 +53,23 @@ dbkjs.Layer = dbkjs.Class({
         
         switch (layertype) {
             case "TMS":
+                // XXX in json you can't create OpenLayers objects. The following
+                // properties in params are converted to OpenLayers objects here:
+
+                // tileOrigin: [<lon>, <lat>] -> new OpenLayers.LonLat(<lon>, <lat>)
+                // maxExtent: [<minx>, <miny>, <maxx>, <maxy>] -> new OpenLayers.Bounds(<minx>, <miny>, <maxx>, <maxy>)
+                // projection: "EPSG:1234" -> new OpenLayers.Projection("EPSG:1234")
+
+                if($.isArray(params.tileOrigin)) {
+	                params.tileOrigin = new OpenLayers.LonLat(params.tileOrigin[0], params.tileOrigin[1]);
+                }
+                if($.isArray(params.maxExtent)) {
+	                var me = params.maxExtent;
+	                params.maxExtent = new OpenLayers.Bounds(me[0], me[1], me[2], me[3]);
+                }
+                if(typeof params.projection == "string") {
+	                params.projection = new OpenLayers.Projection(params.projection);
+                }
                 var ly = new OpenLayers.Layer.TMS(name, url,
                     params,
                     options


### PR DESCRIPTION
Extra kolom layertype in organisations.wms tabel vereist:

```
alter table organisation.wms add column layertype varchar default 'WMS';

comment on column organisation.wms.layertype is 'layertype parameter voor Layer.initialize(); zie ook dbkjs.successAuth() looping over dbkjs.options.organisation.wms';
```

N.B. code is backwards compatible ook zonder deze kolom.

De OpenLayers params moeten in de wms tabel worden ingesteld. Voorbeeld van een TMS kaartlaag:

```
insert into organisation.wms(name, url, layertype, enabled, parent, params, options, "index") values (
    'Brandkranen',
    'http://mijn-server/brandkranen_tms/',
    'TMS',
    true,
    '#overlaypanel_b1',
    '{
        "layername": "", "type": "png", "serviceVersion": "",
        "transitionEffect": null,
        "tileOrigin": [-285401.92, 22598.08],
        "resolutions": [3.36, 1.68, 0.84, 0.42, 0.21],
        "zoomOffset": 0,
        "units": "m",
        "maxExtent": [-285401.92, 22598.08, 595401.92, 903401.92],
        "projection": "EPSG:28992",
        "sphericalMercator": false,
        "isBaseLayer": false,
        "visibility": false
    }',
    null,
    1);
```

Nadeel is dat in JSON geen OpenLayers objecten kunnen worden gemaakt. Daarom dat in Layer.js voor TMS de properties tileOrigin, maxExtent en projecten speciaal worden behandeld en omgezet worden in OpenLayers objecten.
