### PR TITLE
Style use feature attributes

### DIFF
--- a/nodeless/html/index.html
+++ b/nodeless/html/index.html
@@ -121,6 +121,7 @@
     <script src="js/dbkjs/modules/geolocate.js" type="text/javascript"></script>
     <script src="js/dbkjs/modules/livep2000.js" type="text/javascript"></script>
     <script src="js/dbkjs/modules/onscreenkeyboard.js" type="text/javascript"></script>
+    <script src="js/dbkjs/modules/vrhincidenten.js" type="text/javascript"></script>
     <script src="js/dbkjs/images_base64.js"></script>
     <script src="js/dbkjs/gui.js" type="text/javascript"></script>
     <script src="js/dbkjs/layers.js" type="text/javascript"></script>

--- a/public/js/dbkjs/config/styles.js
+++ b/public/js/dbkjs/config/styles.js
@@ -580,7 +580,7 @@ dbkjs.config.styles = {
                     }
                 },
                 myradius: function(feature) {
-                    return dbkjs.scaleStyleValue(12, feature.radius);
+                    return dbkjs.scaleStyleValue(12, feature.attributes.radius);
                 },
                 mydisplay: function(feature) {
                     if (dbkjs.options.visibleCategories && feature.attributes.category &&
@@ -597,7 +597,7 @@ dbkjs.config.styles = {
         }, {
             context: {
                 myradius: function(feature) {
-                    return dbkjs.scaleStyleValue(20, feature.radius, 1.66);
+                    return dbkjs.scaleStyleValue(20, feature.attributes.radius, 1.66);
                 }
             }
         }), 'temporary': new OpenLayers.Style({
@@ -605,7 +605,7 @@ dbkjs.config.styles = {
         }, {
             context: {
                 myradius: function(feature) {
-                    return dbkjs.scaleStyleValue(24, feature.radius, 2);
+                    return dbkjs.scaleStyleValue(24, feature.attributes.radius, 2);
                 }
             }
         })
@@ -654,7 +654,7 @@ dbkjs.config.styles = {
         }, {
             context: {
                 mysize: function(feature) {
-                    return dbkjs.scaleStyleValue(12, feature.scale);
+                    return dbkjs.scaleStyleValue(12, feature.attributes.scale);
                 },
                 myRotation: function(feature) {
                     if (parseFloat(feature.attributes.rotation) !== 0.0) {

--- a/public/js/dbkjs/dbkjs.js
+++ b/public/js/dbkjs/dbkjs.js
@@ -393,7 +393,7 @@ dbkjs.documentReady = function () {
         });
         document.title = dbkjs.options.APPLICATION + ' ' + dbkjs.options.VERSION;
         OpenLayers.Lang[dbkjsLang] = OpenLayers.Util.applyDefaults(
-            {'Scale = 1 : ${scaleDenom}': t("app.scale")}
+            {'Scale = 1 : ${scaleDenom}': i18n.t("app.scale")}
         );
         OpenLayers.Lang.setCode(dbkjsLang);
         if (dbkjs.viewmode !== 'fullscreen') {

--- a/public/js/dbkjs/dbkjs.js
+++ b/public/js/dbkjs/dbkjs.js
@@ -161,7 +161,8 @@ dbkjs.successAuth = function () {
 
     //register modules
     $.each(dbkjs.modules, function (mod_index, module) {
-        if ($.inArray(mod_index, dbkjs.options.organisation.modules) > -1) {
+        if ($.inArray(mod_index, dbkjs.options.organisation.modules) > -1
+	|| (dbkjs.options.additionalModules && $.inArray(mod_index, dbkjs.options.additionalModules) > -1)) {
             if (module.register) {
                 module.register({namespace: dbkjs.options.organisation.workspace, url: 'geoserver/', visible: true, viewmode: dbkjs.viewmode});
             }


### PR DESCRIPTION
Style for brandweervoorziening did not use radius attribute of feature but always the default value because of incorrect reference (feature.radius instead of feature.attributes.radius). Same for size of tekstobject style.

Error caught by @ankeur